### PR TITLE
Add SCM polling trigger and skip default checkout

### DIFF
--- a/jenkins/JenkinsFile
+++ b/jenkins/JenkinsFile
@@ -1,5 +1,14 @@
 pipeline{
     agent any
+
+    triggers {
+        pollSCM('H/5 * * * *') // Checks for changes every 5 minutes
+    }
+
+    options {
+        skipDefaultCheckout(true)
+    }
+
     stages{
         stage("Install Dependencies"){
              when {


### PR DESCRIPTION
Configured the Jenkins pipeline to poll SCM for changes every 5 minutes and added an option to skip the default source code checkout.